### PR TITLE
Update to latest & android compile fixes

### DIFF
--- a/src/entt/config/config.h
+++ b/src/entt/config/config.h
@@ -1,6 +1,7 @@
 #ifndef ENTT_CONFIG_CONFIG_H
 #define ENTT_CONFIG_CONFIG_H
 
+#define ENTT_NOEXCEPT
 
 #ifndef ENTT_NOEXCEPT
 #define ENTT_NOEXCEPT noexcept

--- a/src/entt/core/monostate.hpp
+++ b/src/entt/core/monostate.hpp
@@ -31,7 +31,7 @@ struct Monostate {
      */
     template<typename Type>
     void operator=(Type val) const ENTT_NOEXCEPT {
-        Monostate::value<Type> = val;
+        Monostate::Atomic<Type>::value = val;
     }
 
     /**
@@ -41,18 +41,20 @@ struct Monostate {
      */
     template<typename Type>
     operator Type() const ENTT_NOEXCEPT {
-        return Monostate::value<Type>;
+        return Monostate::Atomic<Type>::value;
     }
 
 private:
     template<typename Type>
-    static std::atomic<Type> value;
+    struct Atomic {
+        static std::atomic<Type> value;
+    };
 };
 
 
 template<HashedString::hash_type ID>
 template<typename Type>
-std::atomic<Type> Monostate<ID>::value{};
+std::atomic<Type> Monostate<ID>::Atomic<Type>::value{};
 
 
 }

--- a/src/entt/entity/entity.hpp
+++ b/src/entt/entity/entity.hpp
@@ -19,7 +19,9 @@ namespace internal {
 
 
 template<typename Entity>
-static constexpr auto null = ~typename entt_traits<Entity>::entity_type{};
+struct NullTrait {
+    static constexpr auto value = ~typename entt_traits<Entity>::entity_type{};
+};
 
 
 struct Null {
@@ -27,7 +29,7 @@ struct Null {
 
     template<typename Entity>
     constexpr operator Entity() const ENTT_NOEXCEPT {
-        return null<Entity>;
+        return NullTrait<Entity>::value;
     }
 
     constexpr bool operator==(Null) const ENTT_NOEXCEPT {
@@ -40,12 +42,12 @@ struct Null {
 
     template<typename Entity>
     constexpr bool operator==(const Entity entity) const ENTT_NOEXCEPT {
-        return entity == null<Entity>;
+        return entity == NullTrait<Entity>::value;
     }
 
     template<typename Entity>
     constexpr bool operator!=(const Entity entity) const ENTT_NOEXCEPT {
-        return entity != null<Entity>;
+        return entity != NullTrait<Entity>::value;
     }
 };
 


### PR DESCRIPTION
## Changes
- By default don't use  `noexcept`, it is varied across all different compilers and STLs so `= default` is good enough
- Android GCC 4.9 doesn't support templated variables, use structs instead

Note: There was some git branch juggling that happened to avoid a massive amount of incompatible merge conflicts. The previous state has been kept in the `runtimecore-old-2018...` branch