### PR TITLE
conan: Remove header only

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -19,6 +19,3 @@ class EnttConan(ConanFile):
 
         # headers
         self.copy("*.h*", src=base + "src/entt", dst=relative + "src/entt")
-
-    def package_id(self):
-        self.info.header_only()


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/694

Using header only actually invalidates all settings. These settings are
useful for executable permissions and line endings.