### PR TITLE
Check 'Exclude' before for loop, prevent unreachable code

### DIFF
--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -249,8 +249,10 @@ class basic_common_view {
 protected:
     /*! @cond TURN_OFF_DOXYGEN */
     basic_common_view() noexcept {
-        for(size_type pos{}; pos < Exclude; ++pos) {
-            filter[pos] = internal::view_placeholder<Type>();
+        if constexpr(Exclude) {
+            for(size_type pos{}; pos < Exclude; ++pos) {
+                filter[pos] = internal::view_placeholder<Type>();
+            }
         }
     }
 


### PR DESCRIPTION
No idea how this started getting flagged up based on adding the hardening flag, but this constructor is erroring on windows builds as unreachable code. The for loop condition is a template parameter, so it seems in this case it is being specified as 0. Wrapping the for loop in an ifconstexpr on that parameter addresses the unreachable code error.